### PR TITLE
Add the configuration_version field to event hash

### DIFF
--- a/lib/puppet/reports/logstash.rb
+++ b/lib/puppet/reports/logstash.rb
@@ -44,6 +44,7 @@ Puppet::Reports.register_report(:logstash) do
     event["environment"] = self.environment
     event["report_format"] = self.report_format
     event["puppet_version"] = self.puppet_version
+    event["configuration_version"] = self.configuration_version
     event["status"] = self.status
     event["start_time"] = self.logs.first.time.utc.iso8601
     event["end_time"] = self.logs.last.time.utc.iso8601


### PR DESCRIPTION
Pulling configuration_version out into its own field is useful when joining data between node runs in Elasticsearch and the puppet codebase in source control in order to correlate failures with newer commits.