### PR TITLE
Adding resource_statuses and a config toggle for the same

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,7 @@
 class logstash_reporter (
   $logstash_host = '127.0.0.1',
   $logstash_port = 5999,
+  $logstash_resource_status = false,
   $config_file   = $::logstash_reporter::params::config_file,
   $config_owner  = $::logstash_reporter::params::config_owner,
   $config_group  = $::logstash_reporter::params::config_group,

--- a/templates/logstash.yaml.erb
+++ b/templates/logstash.yaml.erb
@@ -1,3 +1,4 @@
 ---
 :host: <%= scope.lookupvar('logstash_host') %>
 :port: <%= scope.lookupvar('logstash_port') %>
+:resource_status: <%= scope.lookupvar('logstash_resource_status') %>


### PR DESCRIPTION
Only store resource_statuses in elasticsearch if those resources are "interesting". Interesting resources are resources that are either out_of_sync or changed. I avoided use of report values that were marked for deprecation in future report formats.

I also placed a toggle that gates the activation of this feature and set it disabled by default since it's quite a lot of data if there is a lot of flux in an environment.