### PR TITLE
fix pe-puppet user default

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,8 +31,8 @@ class logstash_reporter::params {
 
   if( $::is_pe == true ) {
     $config_file = '/etc/puppetlabs/puppet/logstash.yaml'
-    $config_owner = 'pe_puppet'
-    $config_group = 'pe_puppet'
+    $config_owner = 'pe-puppet'
+    $config_group = 'pe-puppet'
   } elsif versioncmp($::puppetversion, '4.0.0') >= 0 {
     $config_file = '/etc/puppetlabs/puppet/logstash.yaml'
     $config_owner = 'puppet'

--- a/spec/classes/logstash_reporter_init_spec.rb
+++ b/spec/classes/logstash_reporter_init_spec.rb
@@ -13,7 +13,7 @@ describe 'logstash_reporter', :type => :class do
     let(:facts) { { :is_pe => true } }
     it { should contain_class('logstash_reporter') }
     it { should contain_class('logstash_reporter::params') }
-    it { should contain_file('/etc/puppetlabs/puppet/logstash.yaml').with(:owner => 'pe_puppet') }
+    it { should contain_file('/etc/puppetlabs/puppet/logstash.yaml').with(:owner => 'pe-puppet') }
   end
 
   context 'puppet 4' do
@@ -23,4 +23,3 @@ describe 'logstash_reporter', :type => :class do
     it { should contain_file('/etc/puppetlabs/puppet/logstash.yaml').with(:owner => 'puppet') }
   end
 end
-


### PR DESCRIPTION
Fixes error on PE 3.8.2 puppet master

```
Error: Could not set 'file' on ensure: Could not find user pe_puppet at 51:/etc/puppetlabs/puppet/environments/production/modules/logstash_reporter/manifests/init.pp
Error: Could not set 'file' on ensure: Could not find user pe_puppet at 51:/etc/puppetlabs/puppet/environments/production/modules/logstash_reporter/manifests/init.pp
Wrapped exception:
Could not find user pe_puppet
Error: /Stage[main]/Logstash_reporter/File[/etc/puppetlabs/puppet/logstash.yaml]/ensure: change from absent to file failed: Could not set 'file' on ensure: Could not find user pe_puppet at 51:/etc/puppetlabs/puppet/environments/production/modules/logstash_reporter/manifests/init.pp
```
