### PR TITLE
Adds pe_server_version in lieu of is_pe, which no longer works in 2015

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,7 +29,7 @@
 #
 class logstash_reporter::params {
 
-  if( $::is_pe == true ) {
+  if( $::pe_server_version ) {
     $config_file = '/etc/puppetlabs/puppet/logstash.yaml'
     $config_owner = 'pe-puppet'
     $config_group = 'pe-puppet'


### PR DESCRIPTION
I'm not sure if this fixes open source users, but for our enterprise install, is_pe is now gone. Really wish puppet would stop removing facts etc. that people are using in lots of existing modules, but this branch fixes the logic for us.